### PR TITLE
[codex] fix npm/npx compatibility in run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository provides a **Windows-only runner** that extracts the macOS Codex
 - Node.js
 - 7-Zip (`7z` in PATH)
 - If 7-Zip is not installed, the runner will try `winget` or download a portable copy
-- Codex CLI installed (`npm i -g @openai/codex`)
+- Codex CLI installed (`pnpm add -g @openai/codex`)
 
 ## Quick Start
 1. Place your DMG in the repo root (default name `Codex.dmg`).


### PR DESCRIPTION
## Summary
Running `./scripts/run.ps1` could fail before app launch on some Windows/npm setups with `npm error could not determine executable to run`, followed by `package.json not found.` because `app.asar` never unpacked.

## User Impact
Users on affected machines hit a hard stop during setup and cannot launch the extracted app. The failure mode looked like a missing `package.json`, but the real break happened earlier in the asar unpack step.

## Root Cause
The script relied on PowerShell npm shims (`npx` / `npm`) that are parsed differently across machine setups (notably newer npm + pwsh wrappers), causing command mangling and failed asar extraction.

## Fix
The script now resolves command paths per machine and supports both behaviors:
- Adds `Resolve-CommandPath` to select available command variants (`npm.cmd`/`npm`, `npx.cmd`/`npx`).
- Uses resolved npm command for `npm root -g`, `npm init`, and `npm install`.
- During asar unpack:
  - Tries resolved `npx` first when available.
  - Falls back to `npm exec --package=@electron/asar` if `npx` fails.
  - Fails fast with a clear error only if both paths fail.
- Clears `work/app` before unpacking to avoid stale partial extraction artifacts.

## Validation
- Ran `./scripts/run.ps1 -NoLaunch` after the changes.
- Confirmed it proceeds through:
  - `=== Unpacking app.asar ===`
  - `=== Reading app metadata ===`
- Confirmed it no longer fails with `package.json not found` in the reproduced environment.

## Summary by Sourcery

Improve Windows run script compatibility with different npm/npx setups to ensure reliable app.asar unpacking and app startup.

Bug Fixes:
- Resolve npm and npx command paths dynamically to avoid failures on environments where PowerShell shims behave differently.
- Add a fallback extraction path using npm exec when npx-based app.asar extraction fails, preventing false package.json-not-found errors.
- Clear the app working directory before unpacking app.asar to avoid issues from stale or partial extraction artifacts.

Enhancements:
- Reuse the resolved npm command for subsequent npm root, init, and install operations to standardize script behavior across machines.